### PR TITLE
Implement FANTASY-20 game info endpoints

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -14,6 +14,7 @@ from app.services.scoring import update_weekly_team_scores as _update_weekly_tea
 from .auth import router as auth_router
 from .draft import router as draft_router
 from .endpoints_v1 import router as v1_router
+from .game_router import router as game_router
 from .logs import router as logs_router
 from .users import router as users_router
 
@@ -33,6 +34,7 @@ router.include_router(logs_router)
 
 # V1 public endpoints
 router.include_router(v1_router)
+router.include_router(game_router, prefix="/api/v1")
 
 
 @router.get("/health")

--- a/app/api/game_router.py
+++ b/app/api/game_router.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import httpx
+from fastapi import APIRouter, HTTPException, Path
+
+from app.api.schemas import (
+    GamePlayByPlayOut,
+    GameSummaryBoxScoreTeamOut,
+    GameSummaryOut,
+    GameSummaryPlayerStatsOut,
+    GameInfoOut,
+    PlayByPlayEventOut,
+)
+from app.external_apis.rapidapi_client import RapidApiClient, RetryError, wnba_client
+
+router = APIRouter(prefix="/games", tags=["games"])
+
+
+def _safe_int(val: Any) -> int:
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _map_game_summary(data: dict[str, Any]) -> GameSummaryOut:
+    competition = (data.get("header", {}).get("competitions") or [{}])[0]
+    game_id = str(competition.get("id") or data.get("gameId", ""))
+
+    game_info = GameInfoOut(
+        game_id=game_id,
+        venue=competition.get("venue", {}).get("fullName"),
+        status=competition.get("status", {}).get("type", {}).get("description"),
+    )
+
+    competitor_meta = {}
+    for comp in competition.get("competitors", []):
+        tid = str(comp.get("id") or comp.get("team", {}).get("id", ""))
+        competitor_meta[tid] = {
+            "abbr": comp.get("team", {}).get("abbreviation"),
+            "score": _safe_int(comp.get("score")),
+        }
+
+    teams: List[GameSummaryBoxScoreTeamOut] = []
+    for team_block in data.get("boxscore", {}).get("players", []):
+        team = team_block.get("team", {})
+        team_id = str(team.get("id", ""))
+        players: List[GameSummaryPlayerStatsOut] = []
+        for stats_block in team_block.get("statistics", []):
+            for athlete in stats_block.get("athletes", []):
+                info = athlete.get("athlete", {})
+                stats = athlete.get("stats", [])
+                players.append(
+                    GameSummaryPlayerStatsOut(
+                        player_id=str(info.get("id")),
+                        player_name=info.get("displayName"),
+                        points=_safe_int(stats[-1]) if stats else 0,
+                        rebounds=_safe_int(stats[6]) if len(stats) > 6 else 0,
+                        assists=_safe_int(stats[7]) if len(stats) > 7 else 0,
+                    )
+                )
+        meta = competitor_meta.get(team_id, {})
+        teams.append(
+            GameSummaryBoxScoreTeamOut(
+                team_id=team_id,
+                team_abbr=meta.get("abbr"),
+                score=meta.get("score", 0),
+                players=players,
+            )
+        )
+
+    return GameSummaryOut(game=game_info, teams=teams)
+
+
+def _map_playbyplay(data: dict[str, Any]) -> GamePlayByPlayOut:
+    competition = (data.get("header", {}).get("competitions") or [{}])[0]
+    game_id = str(competition.get("id") or data.get("gameId", ""))
+    events: List[PlayByPlayEventOut] = []
+    for play in data.get("plays", []):
+        events.append(
+            PlayByPlayEventOut(
+                clock=play.get("clock", {}).get("displayValue"),
+                description=play.get("text"),
+                team_id=str(play.get("team", {}).get("id")) if play.get("team") else None,
+                period=play.get("period", {}).get("number"),
+            )
+        )
+    return GamePlayByPlayOut(game_id=game_id, events=events)
+
+
+@router.get("/{game_id}/summary", response_model=GameSummaryOut)
+async def game_summary(game_id: str = Path(..., description="Game ID")) -> GameSummaryOut:
+    """Return a game summary including box scores."""
+
+    try:
+        raw = await wnba_client.fetch_game_summary(game_id)
+    except RetryError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="Failed to fetch game summary") from exc
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        status = 404 if exc.response.status_code == 404 else 502
+        raise HTTPException(status_code=status, detail="Failed to fetch game summary") from exc
+
+    if not raw:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return _map_game_summary(raw)
+
+
+@router.get("/{game_id}/playbyplay", response_model=GamePlayByPlayOut)
+async def game_playbyplay(game_id: str = Path(..., description="Game ID")) -> GamePlayByPlayOut:
+    """Return play-by-play data for a game."""
+
+    try:
+        raw = await wnba_client.fetch_game_playbyplay(game_id)
+    except RetryError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="Failed to fetch play-by-play") from exc
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        status = 404 if exc.response.status_code == 404 else 502
+        raise HTTPException(status_code=status, detail="Failed to fetch play-by-play") from exc
+
+    if not raw:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return _map_playbyplay(raw)
+

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -156,3 +156,53 @@ class TeamUpdate(BaseModel):
     """Schema for updating an existing team."""
 
     name: Optional[str] = None
+
+
+class GameSummaryPlayerStatsOut(BaseModel):
+    """Player statistics for a game summary."""
+
+    player_id: str
+    player_name: str
+    points: int
+    rebounds: int
+    assists: int
+
+
+class GameSummaryBoxScoreTeamOut(BaseModel):
+    """Box score data for a single team."""
+
+    team_id: str
+    team_abbr: Optional[str] = None
+    score: int
+    players: List[GameSummaryPlayerStatsOut] = Field(default_factory=list)
+
+
+class GameInfoOut(BaseModel):
+    """Basic information about a game."""
+
+    game_id: str
+    venue: Optional[str] = None
+    status: Optional[str] = None
+
+
+class GameSummaryOut(BaseModel):
+    """Combined game summary with box scores."""
+
+    game: GameInfoOut
+    teams: List[GameSummaryBoxScoreTeamOut]
+
+
+class PlayByPlayEventOut(BaseModel):
+    """Single play in the play-by-play log."""
+
+    clock: Optional[str] = None
+    description: str
+    team_id: Optional[str] = None
+    period: Optional[int] = None
+
+
+class GamePlayByPlayOut(BaseModel):
+    """Play-by-play data for a game."""
+
+    game_id: str
+    events: List[PlayByPlayEventOut]

--- a/app/external_apis/rapidapi_client.py
+++ b/app/external_apis/rapidapi_client.py
@@ -87,6 +87,16 @@ class RapidApiClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def fetch_game_summary(self, game_id: str) -> Any:
+        """Fetch game summary data for a specific game."""
+
+        return await self._get_json("wnbasummary", params={"gameId": game_id})
+
+    async def fetch_game_playbyplay(self, game_id: str) -> Any:
+        """Fetch play-by-play data for a specific game."""
+
+        return await self._get_json("wnbaplay", params={"gameId": game_id})
+
     async def close(self) -> None:
         """Close the client session."""
         if self._client is not None:

--- a/tests/test_game_endpoints.py
+++ b/tests/test_game_endpoints.py
@@ -1,0 +1,99 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.external_apis.rapidapi_client import RetryError, wnba_client
+
+summary_response = {
+    "header": {
+        "competitions": [
+            {
+                "id": "game123",
+                "status": {"type": {"description": "Final"}},
+                "venue": {"fullName": "Arena"},
+                "competitors": [
+                    {"id": "1", "team": {"id": "1", "abbreviation": "AAA"}, "score": "90"},
+                    {"id": "2", "team": {"id": "2", "abbreviation": "BBB"}, "score": "85"},
+                ],
+            }
+        ]
+    },
+    "boxscore": {
+        "players": [
+            {
+                "team": {"id": "1"},
+                "statistics": [
+                    {
+                        "athletes": [
+                            {
+                                "athlete": {"id": "p1", "displayName": "Player 1"},
+                                "stats": ["0", "0", "0", "0", "0", "0", "1", "2", "0", "0", "0", "0", "0", "5"],
+                            }
+                        ]
+                    }
+                ],
+            },
+            {
+                "team": {"id": "2"},
+                "statistics": [
+                    {
+                        "athletes": [
+                            {
+                                "athlete": {"id": "p2", "displayName": "Player 2"},
+                                "stats": ["0", "0", "0", "0", "0", "0", "2", "1", "0", "0", "0", "0", "0", "7"],
+                            }
+                        ]
+                    }
+                ],
+            },
+        ]
+    },
+}
+
+play_response = {
+    "header": {"competitions": [{"id": "game123"}]},
+    "plays": [
+        {"clock": {"displayValue": "10:00"}, "text": "Jump ball", "team": {"id": "1"}, "period": {"number": 1}},
+        {
+            "clock": {"displayValue": "9:55"},
+            "text": "Player 1 makes shot",
+            "team": {"id": "1"},
+            "period": {"number": 1},
+        },
+    ],
+}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_game_summary_endpoint(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_game_summary", AsyncMock(return_value=summary_response))
+
+    resp = client.get("/api/v1/games/game123/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["game"]["game_id"] == "game123"
+    assert len(data["teams"]) == 2
+    assert data["teams"][0]["players"][0]["player_id"] == "p1"
+
+
+def test_game_playbyplay_endpoint(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_game_playbyplay", AsyncMock(return_value=play_response))
+
+    resp = client.get("/api/v1/games/game123/playbyplay")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["game_id"] == "game123"
+    assert len(data["events"]) == 2
+
+
+def test_game_summary_error(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_game_summary", AsyncMock(side_effect=RetryError("fail")))
+
+    resp = client.get("/api/v1/games/bad/summary")
+    assert resp.status_code == 502

--- a/tests/test_rapidapi_client.py
+++ b/tests/test_rapidapi_client.py
@@ -91,3 +91,19 @@ class TestRapidApiClient:
 
         mock_client.aclose.assert_called_once()
         assert client._client is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_summary(self, mock_env_vars):
+        client = RapidApiClient(base_url="https://test.com", host="test.com")
+        with patch.object(client, "_get_json", AsyncMock(return_value={"ok": True})) as mock_get:
+            result = await client.fetch_game_summary("123")
+            mock_get.assert_called_once_with("wnbasummary", params={"gameId": "123"})
+            assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_fetch_game_playbyplay(self, mock_env_vars):
+        client = RapidApiClient(base_url="https://test.com", host="test.com")
+        with patch.object(client, "_get_json", AsyncMock(return_value={"ok": True})) as mock_get:
+            result = await client.fetch_game_playbyplay("999")
+            mock_get.assert_called_once_with("wnbaplay", params={"gameId": "999"})
+            assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- add data models for game summary and play‑by‑play
- extend `RapidApiClient` with summary and play‑by‑play methods
- create `game_router` with `/games/{game_id}/summary` and `/playbyplay`
- wire new router into API
- test client helpers and endpoints

## Testing
- `make format` *(fails: unexpected argument '--fix')*
- `make lint` *(fails: unrecognized subcommand '.')*
- `make test` *(fails: Command not found: pytest)*