### PR TITLE
Implement league info endpoints

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -15,6 +15,7 @@ from .auth import router as auth_router
 from .draft import router as draft_router
 from .endpoints_v1 import router as v1_router
 from .game_router import router as game_router
+from .league_router import router as league_router
 from .logs import router as logs_router
 from .users import router as users_router
 
@@ -35,6 +36,7 @@ router.include_router(logs_router)
 # V1 public endpoints
 router.include_router(v1_router)
 router.include_router(game_router, prefix="/api/v1")
+router.include_router(league_router, prefix="/api/v1")
 
 
 @router.get("/health")

--- a/app/api/league_router.py
+++ b/app/api/league_router.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, List
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from app.external_apis.rapidapi_client import RetryError, wnba_client
+
+from .schemas import (
+    LeagueInjuryReportOut,
+    NewsArticleOut,
+    PlayerInjuryDetailOut,
+    ScheduleDayOut,
+    ScheduledGameCompetitorOut,
+    ScheduledGameOut,
+    TeamInjuryListOut,
+)
+
+router = APIRouter(tags=["league"])
+
+
+def _safe_int(val: Any) -> int:
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _map_schedule(games: List[dict[str, Any]], date_str: str) -> ScheduleDayOut:
+    mapped_games: List[ScheduledGameOut] = []
+    for game in games:
+        competitors: List[ScheduledGameCompetitorOut] = []
+        for comp in game.get("competitors", game.get("teams", [])):
+            competitors.append(
+                ScheduledGameCompetitorOut(
+                    team_id=str(comp.get("id")),
+                    abbrev=comp.get("abbrev"),
+                    display_name=comp.get("displayName"),
+                    score=_safe_int(comp.get("score")),
+                    is_home=comp.get("isHome"),
+                    winner=comp.get("winner"),
+                )
+            )
+        mapped_games.append(
+            ScheduledGameOut(
+                game_id=str(game.get("id")),
+                start_time=game.get("date"),
+                venue=game.get("venue", {}).get("fullName"),
+                completed=game.get("completed"),
+                competitors=competitors,
+            )
+        )
+    return ScheduleDayOut(date=date_str, games=mapped_games)
+
+
+def _map_news(raw: dict[str, Any]) -> List[NewsArticleOut]:
+    articles: List[NewsArticleOut] = []
+    for item in raw.get("articles", raw.get("data", [])):
+        link_val = item.get("link")
+        if isinstance(link_val, dict):
+            link_val = link_val.get("href")
+        articles.append(
+            NewsArticleOut(
+                headline=item.get("headline"), link=link_val, source=item.get("source"), published=item.get("published")
+            )
+        )
+    return articles
+
+
+def _map_injuries(raw: dict[str, Any]) -> LeagueInjuryReportOut:
+    teams: List[TeamInjuryListOut] = []
+    for team in raw.get("teams", []):
+        players: List[PlayerInjuryDetailOut] = []
+        for p in team.get("injuries", []):
+            players.append(
+                PlayerInjuryDetailOut(
+                    player_id=str(p.get("id") or p.get("playerId")),
+                    player_name=p.get("name") or p.get("fullName"),
+                    position=p.get("position"),
+                    status=p.get("status"),
+                    comment=p.get("comment") or p.get("details"),
+                )
+            )
+        teams.append(TeamInjuryListOut(team_id=str(team.get("id")), team_name=team.get("name"), players=players))
+    return LeagueInjuryReportOut(teams=teams)
+
+
+@router.get("/schedule", response_model=ScheduleDayOut)
+async def get_schedule(date: str | None = Query(None, description="YYYY-MM-DD")) -> ScheduleDayOut:
+    if date:
+        try:
+            date_obj = dt.datetime.strptime(date, "%Y-%m-%d").date()
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid date format – use YYYY-MM-DD")
+    else:
+        date_obj = dt.datetime.utcnow().date()
+
+    try:
+        games = await wnba_client.fetch_schedule(
+            date_obj.strftime("%Y"), date_obj.strftime("%m"), date_obj.strftime("%d")
+        )
+    except RetryError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="Failed to fetch schedule") from exc
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        status = 404 if exc.response.status_code == 404 else 502
+        raise HTTPException(status_code=status, detail="Failed to fetch schedule") from exc
+
+    return _map_schedule(games, date_obj.isoformat())
+
+
+@router.get("/news", response_model=List[NewsArticleOut])
+async def get_news(limit: int = Query(20, ge=1, le=100)) -> List[NewsArticleOut]:
+    try:
+        raw = await wnba_client.fetch_wnba_news(limit)
+    except RetryError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="Failed to fetch news") from exc
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        status = 404 if exc.response.status_code == 404 else 502
+        raise HTTPException(status_code=status, detail="Failed to fetch news") from exc
+
+    return _map_news(raw)
+
+
+@router.get("/injuries", response_model=LeagueInjuryReportOut)
+async def get_injuries() -> LeagueInjuryReportOut:
+    try:
+        raw = await wnba_client.fetch_league_injuries()
+    except RetryError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="Failed to fetch injuries") from exc
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+        status = 404 if exc.response.status_code == 404 else 502
+        raise HTTPException(status_code=status, detail="Failed to fetch injuries") from exc
+
+    return _map_injuries(raw)

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -206,3 +206,64 @@ class GamePlayByPlayOut(BaseModel):
 
     game_id: str
     events: List[PlayByPlayEventOut]
+
+
+class ScheduledGameCompetitorOut(BaseModel):
+    """Team information within a scheduled game."""
+
+    team_id: str
+    abbrev: Optional[str] = None
+    display_name: Optional[str] = None
+    score: Optional[int] = None
+    is_home: Optional[bool] = None
+    winner: Optional[bool] = None
+
+
+class ScheduledGameOut(BaseModel):
+    """Basic scheduled game info."""
+
+    game_id: str
+    start_time: Optional[str] = None
+    venue: Optional[str] = None
+    completed: Optional[bool] = None
+    competitors: List[ScheduledGameCompetitorOut] = Field(default_factory=list)
+
+
+class ScheduleDayOut(BaseModel):
+    """List of games for a given day."""
+
+    date: str
+    games: List[ScheduledGameOut] = Field(default_factory=list)
+
+
+class NewsArticleOut(BaseModel):
+    """Representation of a news article."""
+
+    headline: Optional[str] = None
+    link: Optional[str] = None
+    source: Optional[str] = None
+    published: Optional[str] = None
+
+
+class PlayerInjuryDetailOut(BaseModel):
+    """Details about a player's injury status."""
+
+    player_id: Optional[str] = None
+    player_name: Optional[str] = None
+    position: Optional[str] = None
+    status: Optional[str] = None
+    comment: Optional[str] = None
+
+
+class TeamInjuryListOut(BaseModel):
+    """Injury list for a team."""
+
+    team_id: str
+    team_name: Optional[str] = None
+    players: List[PlayerInjuryDetailOut] = Field(default_factory=list)
+
+
+class LeagueInjuryReportOut(BaseModel):
+    """Aggregated league-wide injuries."""
+
+    teams: List[TeamInjuryListOut] = Field(default_factory=list)

--- a/app/external_apis/rapidapi_client.py
+++ b/app/external_apis/rapidapi_client.py
@@ -97,6 +97,26 @@ class RapidApiClient:
 
         return await self._get_json("wnbaplay", params={"gameId": game_id})
 
+    async def fetch_schedule(self, year: str, month: str, day: str) -> Any:
+        """Fetch the schedule for a given date."""
+
+        data = await self._get_json(
+            "wnbaschedule",
+            params={"year": year, "month": month, "day": day},
+        )
+        key = f"{year}{month}{day}"
+        return data.get(key, [])
+
+    async def fetch_wnba_news(self, limit: int = 20) -> Any:
+        """Fetch recent WNBA news articles."""
+
+        return await self._get_json("wnba-news", params={"limit": str(limit)})
+
+    async def fetch_league_injuries(self) -> Any:
+        """Fetch league-wide injury information."""
+
+        return await self._get_json("injuries")
+
     async def close(self) -> None:
         """Close the client session."""
         if self._client is not None:

--- a/tests/test_league_info_endpoints.py
+++ b/tests/test_league_info_endpoints.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.external_apis.rapidapi_client import RetryError, wnba_client
+from app.main import app
+
+schedule_games = [
+    {
+        "id": "401",
+        "date": "2025-05-04T20:00Z",
+        "completed": True,
+        "venue": {"fullName": "Arena"},
+        "competitors": [
+            {"id": "1", "abbrev": "AAA", "displayName": "A Team", "isHome": True, "score": "90", "winner": True},
+            {"id": "2", "abbrev": "BBB", "displayName": "B Team", "isHome": False, "score": "85", "winner": False},
+        ],
+    }
+]
+
+news_raw = {"articles": [{"headline": "News", "link": "http://a", "published": "2025"}]}
+
+injuries_raw = {
+    "teams": [
+        {
+            "id": "1",
+            "name": "A Team",
+            "injuries": [{"id": "p1", "name": "Player 1", "status": "out", "comment": "knee"}],
+        }
+    ]
+}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_schedule_endpoint(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_schedule", AsyncMock(return_value=schedule_games))
+    resp = client.get("/api/v1/schedule?date=2025-05-04")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["date"] == "2025-05-04"
+    assert len(data["games"]) == 1
+    assert data["games"][0]["game_id"] == "401"
+
+
+def test_news_endpoint(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_wnba_news", AsyncMock(return_value=news_raw))
+    resp = client.get("/api/v1/news?limit=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data[0]["headline"] == "News"
+
+
+def test_injuries_endpoint(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_league_injuries", AsyncMock(return_value=injuries_raw))
+    resp = client.get("/api/v1/injuries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["teams"]) == 1
+    assert data["teams"][0]["team_id"] == "1"
+
+
+def test_schedule_error(client, monkeypatch):
+    monkeypatch.setattr(wnba_client, "fetch_schedule", AsyncMock(side_effect=RetryError("fail")))
+    resp = client.get("/api/v1/schedule?date=2025-05-04")
+    assert resp.status_code == 502

--- a/tests/test_rapidapi_client.py
+++ b/tests/test_rapidapi_client.py
@@ -107,3 +107,27 @@ class TestRapidApiClient:
             result = await client.fetch_game_playbyplay("999")
             mock_get.assert_called_once_with("wnbaplay", params={"gameId": "999"})
             assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_fetch_schedule(self, mock_env_vars):
+        client = RapidApiClient(base_url="https://test.com", host="test.com")
+        with patch.object(client, "_get_json", AsyncMock(return_value={"20250101": ["a"]})) as mock_get:
+            result = await client.fetch_schedule("2025", "01", "01")
+            mock_get.assert_called_once_with("wnbaschedule", params={"year": "2025", "month": "01", "day": "01"})
+            assert result == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_wnba_news(self, mock_env_vars):
+        client = RapidApiClient(base_url="https://test.com", host="test.com")
+        with patch.object(client, "_get_json", AsyncMock(return_value={"articles": []})) as mock_get:
+            result = await client.fetch_wnba_news(5)
+            mock_get.assert_called_once_with("wnba-news", params={"limit": "5"})
+            assert result == {"articles": []}
+
+    @pytest.mark.asyncio
+    async def test_fetch_league_injuries(self, mock_env_vars):
+        client = RapidApiClient(base_url="https://test.com", host="test.com")
+        with patch.object(client, "_get_json", AsyncMock(return_value={"teams": []})) as mock_get:
+            result = await client.fetch_league_injuries()
+            mock_get.assert_called_once_with("injuries")
+            assert result == {"teams": []}


### PR DESCRIPTION
## Summary
- add RapidApiClient helpers for schedule, news, and injuries
- define schemas for schedule, news, and league injury reports
- create `league_router` with `/schedule`, `/news`, and `/injuries` endpoints
- wire new router into FastAPI
- extend tests for RapidApiClient
- add integration tests for league info endpoints

## Testing
- `poetry run ruff check app/api/league_router.py app/api/schemas.py tests/test_league_info_endpoints.py tests/test_rapidapi_client.py`
- `poetry run isort app/api/league_router.py app/api/schemas.py tests/test_league_info_endpoints.py tests/test_rapidapi_client.py`
- `poetry run black app/api/league_router.py app/api/schemas.py tests/test_league_info_endpoints.py tests/test_rapidapi_client.py`
- `poetry run ruff check app/api/league_router.py app/api/schemas.py tests/test_league_info_endpoints.py tests/test_rapidapi_client.py`
- `poetry run pytest -q` *(fails: Command not found: pytest)*